### PR TITLE
Bumped size to 50MB

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -49,7 +49,7 @@ k3s kubectl get node
     <div>
       <h5>Simplified &amp; Secure</h5>
       <p>K3s is packaged as a single
-        &lt;40MB binary that reduces the
+        &lt;50MB binary that reduces the
         dependencies and steps needed
         to install, run and auto-update a
         production Kubernetes cluster.</p>


### PR DESCRIPTION
Recent K3s release are no longer less than 40MB, they are now in the range of 42-48MB
See: https://github.com/k3s-io/k3s/releases/tag/v1.21.4%2Bk3s1
Signed-off-by: dereknola <derek.nola@suse.com>